### PR TITLE
ci: tag for each service

### DIFF
--- a/.github/workflows/build_artifacts.yaml
+++ b/.github/workflows/build_artifacts.yaml
@@ -106,10 +106,22 @@ jobs:
           git add -A
           git commit --allow-empty -m "Auto commit by GitHub Actions $VERSION"
           git push -f --set-upstream origin main
+  tag:
+    needs: [ matrix, build, generate ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.matrix.outputs.matrix).service }}
+    steps:
+      - uses: actions/checkout@v4
       - name: Auto Tag
         if: ${{ inputs.opendal_go_version != '' || github.event.client_payload.opendal_go_version != '' }}
         env:
-          TAG: ${{ inputs.opendal_go_version || github.event.client_payload.opendal_go_version }}
+          SERVICE: ${{ matrix.service }} 
+          VERSION: ${{ inputs.opendal_go_version || github.event.client_payload.opendal_go_version }}
         run: |
+          SERVICE=$(echo $SERVICE | tr '-' '_')
+          TAG="$SERVICE/$VERSION"
           git tag $TAG
           git push -f origin $TAG


### PR DESCRIPTION
See the official document  [Wiki: Modules#publishing-a-release](https://go.dev/wiki/Modules#publishing-a-release).

Currently, we only tag the root.

According to Go modules documentation, we must tag each subdirectory separately for multi-module repos.

So to the go-bindings, we will tag it as `bindings/go/v0.0.1` for example.

