### PR TITLE
fix: build error due to the removed feature of blocking-layers of c binding

### DIFF
--- a/.github/workflows/build_artifacts.yaml
+++ b/.github/workflows/build_artifacts.yaml
@@ -75,20 +75,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Setup Service
-        env:
-          OPENDAL_FEATURES: "layers-blocking,services-${{ matrix.service }}"
-        run: |
-          python -m pip install toml
-          python tools/.github/scripts/setup_features.py
       - name: Build ${{ matrix.service }} ${{ matrix.build.target }}
         working-directory: bindings/c
         env:
           SERVICE: ${{ matrix.service }}
           TARGET: ${{ matrix.build.target }}
+          OPENDAL_FEATURES: "opendal/services-${{ matrix.service }}"
           CC: ${{ matrix.build.cc }}
         run: |
-          cargo build --target $TARGET  --release
+          cargo build --target $TARGET --features $OPENDAL_FEATURES --release
           sudo apt install zstd
           zstd -22 ./target/$TARGET/release/libopendal_c.so -o ./libopendal_c.$TARGET.so.zst
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The build workflow failed because of the removed feature of blocking-layers of c binding.